### PR TITLE
Delete gsi because IOAPIC no longer uses legacy interrupt

### DIFF
--- a/hw/i386/virt/acpi.c
+++ b/hw/i386/virt/acpi.c
@@ -51,8 +51,6 @@ typedef struct VirtAcpiState {
 
     GEDState ged_state;
 
-    qemu_irq *gsi;
-
     AcpiPciHpState pcihp_state;
     PCIBus *pci_bus;
 
@@ -250,7 +248,7 @@ static void virt_device_realize(DeviceState *dev, Error **errp)
     sysbus_add_io(sys, ACPI_REDUCED_RESET_IOPORT, &s->reset_iomem);
 }
 
-DeviceState *virt_acpi_init(qemu_irq *gsi, PCIBus *pci_bus)
+DeviceState *virt_acpi_init(PCIBus *pci_bus)
 {
     DeviceState *dev;
     VirtAcpiState *s;
@@ -258,7 +256,6 @@ DeviceState *virt_acpi_init(qemu_irq *gsi, PCIBus *pci_bus)
     dev = sysbus_create_simple(TYPE_VIRT_ACPI, -1, NULL);
 
     s = VIRT_ACPI(dev);
-    s->gsi = gsi;
     s->pci_bus = pci_bus;
 
     if (pci_bus) {

--- a/hw/i386/virt/virt.c
+++ b/hw/i386/virt/virt.c
@@ -132,13 +132,6 @@ static void virt_machine_done(Notifier *notifier, void *data)
     mc->firmware_build_methods.acpi.setup(ms, &vms->acpi_conf);
 }
 
-static void virt_gsi_handler(void *opaque, int n, int level)
-{
-    qemu_irq *ioapic_irq = opaque;
-
-    qemu_set_irq(ioapic_irq[n], level);
-}
-
 static void virt_ioapic_init(VirtMachineState *vms)
 {
     qemu_irq *ioapic_irq;
@@ -164,8 +157,6 @@ static void virt_ioapic_init(VirtMachineState *vms)
     for (i = 0; i < IOAPIC_NUM_PINS; i++) {
         ioapic_irq[i] = qdev_get_gpio_in(ioapic_dev, i);
     }
-
-    vms->gsi = qemu_allocate_irqs(virt_gsi_handler, ioapic_irq, IOAPIC_NUM_PINS);
 }
 
 static void virt_pci_init(VirtMachineState *vms)
@@ -202,7 +193,7 @@ static void virt_machine_state_init(MachineState *machine)
     virt_memory_init(vms);
     virt_pci_init(vms);
     virt_ioapic_init(vms);
-    vms->acpi = virt_acpi_init(vms->gsi, vms->pci_bus);
+    vms->acpi = virt_acpi_init(vms->pci_bus);
 
     vms->apic_id_limit = cpus_init(machine, false);
 

--- a/include/hw/i386/virt.h
+++ b/include/hw/i386/virt.h
@@ -43,9 +43,6 @@ typedef struct {
     /* number of CPUs */
     uint16_t boot_cpus;
 
-    /* GSI */
-    qemu_irq *gsi;
-
     PCIBus *pci_bus;
     ram_addr_t above_4g_mem_size;
 
@@ -67,6 +64,6 @@ typedef struct {
 
 MemoryRegion *virt_memory_init(VirtMachineState *vms);
 
-DeviceState *virt_acpi_init(qemu_irq *gsi, PCIBus *pci_bus);
+DeviceState *virt_acpi_init(PCIBus *pci_bus);
 
 #endif


### PR DESCRIPTION
@sboeuf  I think we don't need gsi in nemu parts for legacy interrupt, right? Not sure if this is used in some other places so just give you the patch and you can quickly test. 